### PR TITLE
add docker installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.gitignore
+Dockerfile
+pics
+.git
+LICENSE
+README.md
+**/*.pbf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 target/
+**/*.pbf
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**
 !**/src/test/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:11-jdk
+LABEL maintainer=nils@gis-ops.com
+
+RUN apt-get update -qq && apt-get install -qq -y maven
+
+WORKDIR /pgr_server
+
+COPY src ./src
+COPY pom.xml .
+
+EXPOSE 8080
+CMD ["mvn", "spring-boot:run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,7 @@ WORKDIR /pgr_server
 COPY src ./src
 COPY pom.xml .
 
+RUN mvn dependency:resolve
+
 EXPOSE 8080
 CMD ["mvn", "spring-boot:run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "2.4"
 networks:
   pgrserver:
+volumes:
+  pgr-postgis-data:
 
 services:
   pgrServer:
@@ -12,7 +14,7 @@ services:
       - POSTGRES_DB=pgr
       - POSTGRES_HOST=pgr_postgis
       - POSTGRES_PORT=5432
-    # network_mode: host  # use this instead of networks for a separate Postgres instance
+    #network_mode: host  # use this instead of networks for a separate Postgres instance
     networks:
       - pgrserver
     ports:
@@ -20,7 +22,7 @@ services:
   pgr_postgis:
     image: kartoza/postgis:13.0
     volumes:
-      - postgis-data:/var/lib/postgresql
+      - pgr-postgis-data:/var/lib/postgresql
     environment:
       - POSTGRES_DB=pgr
       - POSTGRES_USER=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "2.4"
+networks:
+  pgrserver:
+
+services:
+  pgrServer:
+    image: mbasa/pgrserver:latest
+    container_name: pgrserver
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASS=postgres
+      - POSTGRES_DB=pgr
+      - POSTGRES_HOST=pgr_postgis
+      - POSTGRES_PORT=5432
+    # network_mode: host  # use this instead of networks for a separate Postgres instance
+    networks:
+      - pgrserver
+    ports:
+      - 8080:8080
+  pgr_postgis:
+    image: kartoza/postgis:13.0
+    volumes:
+      - postgis-data:/var/lib/postgresql
+    environment:
+      - POSTGRES_DB=pgr
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASS=postgres
+      # Add extensions you need to be enabled by default in the DB. Default are the three specified below
+      - POSTGRES_MULTIPLE_EXTENSIONS=postgis,hstore,pgrouting
+    networks:
+      - pgrserver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,9 +2,9 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 spring.jpa.hibernate.ddl-auto=none
 #spring.jpa.hibernate.show-sql=true
 spring.jpa.database=POSTGRESQL
-spring.datasource.url=jdbc:postgresql://localhost:5432/pgr
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:pgr}
+spring.datasource.username=${POSTGRES_USER:postgres}
+spring.datasource.password=${POSTGRES_PASS:postgres}
 
 spring.jpa.show-sql=true
 spring.jpa.generate-ddl=true


### PR DESCRIPTION
```
docker-compose build pgrserver
docker-compose up -d
```

No need for Java and maven, but the topology still needs to be manually created before. Also sets up the PostGIS container if desired. 

For easier deployment I switched the `application.properties` Postgres variables to use env vars with defaults, so nothing breaks compared to master.

Sorry for the README diffs, Atom introduced them when saving..